### PR TITLE
Use systemd template service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
            enabled=yes
 
 - name: restart and enable nprobe service
-  service: name=nprobe
+  systemd: name=nprobe@none
            state=restarted
            enabled=yes
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,15 +54,13 @@
   command: ethtool -K {{ ansible_default_ipv4.interface }} gro off gso off tso off
   when: ntopng_use_default_nic_as_monitor_interface and ntopng_packages_installed|changed
 
-- name: Configure nprobe (1/2)
-  template: >
-    src=nprobe-none.start.j2
-    dest=/etc/nprobe/nprobe-none.start
-    owner=root
-    group=root
-    mode=0644
+- name: Disable default nprobe service
+  systemd: >
+    name=nprobe
+    state=stopped
+    enabled=no
 
-- name: Configure nprobe (2/2)
+- name: Configure nprobe
   template: >
     src=nprobe-none.conf.j2
     dest=/etc/nprobe/nprobe-none.conf


### PR DESCRIPTION
Fixes #3 
nprobe appears to be full systemd service now, with a `@` instantiation template service available.
The handle is changed to use this template service for the `none' config that ansible template generates.
The nprobe regular services, which by default monitors `lo` and does not export flows is explicitly disabled/stopped as the package install enables/started by default.