### PR TITLE
Configure the minimum template for ntopng to work

### DIFF
--- a/templates/nprobe-none.conf.j2
+++ b/templates/nprobe-none.conf.j2
@@ -2,3 +2,4 @@
 --collector-port={{ ntopng_nprobe_flow_collector_port }}
 -n=none
 -i=none
+-T "@NTOPNG@ %INPUT_SNMP %OUTPUT_SNMP"


### PR DESCRIPTION
As documented here:
https://www.ntop.org/nprobe/best-practices-for-the-collection-of-flows-with-ntopng-and-nprobe/#Templates

@NTOPNG@ is the minimum set of fields for the ntopng to
work. Configuring the nprobe to use this, means that it will added the
fields, zeroed, even if the received flows from netflow device does
not sent them.

Adding INPUT/OUTPUT SNMP allows ntopng to disaggregate the interfaces
if user desires. And most netflow devices send these fields.
See: https://www.ntop.org/guides/ntopng/advanced_features/dynamic_interfaces_disaggregation.html